### PR TITLE
docs: add roadmap issue links for WP items

### DIFF
--- a/docs/00-roadmap/20260112-master-roadmap-1.00W.md
+++ b/docs/00-roadmap/20260112-master-roadmap-1.00W.md
@@ -291,9 +291,18 @@ This roadmap consolidates information from:
 | #69 | Remove Cosine Similarity from match_coordinates() | ✅ **COMPLETE** | **CLOSE ISSUE** |
 | #70 | Special Symbols Validation | 🔍 Needs validation | Cross-reference |
 | #71 | Two-step Retrieval with Fisher-proxy | ✅ **IMPLEMENTED** | **VALIDATE & CLOSE** |
+| [#72](../10-e8-protocol/INDEX.md#issue-72) | WP3.1: Consolidate to Single Coordizer Implementation | ⬜ Not started | Not started |
 | #75 | External LLM Fence with Waypoint Planning | ✅ **IMPLEMENTED** | **VALIDATE & CLOSE** |
 | #76 | Natural Gradient with Geodesic Operations | ✅ **IMPLEMENTED** | **VALIDATE & CLOSE** |
 | #77 | Coherence Harness with Smoothness Metrics | ✅ **IMPLEMENTED** | **VALIDATE & CLOSE** |
+| [#78](../10-e8-protocol/INDEX.md#issue-78) | WP5.1: Formal Pantheon Registry with Role Contracts | ⬜ Not started | Not started |
+| [#79](../10-e8-protocol/INDEX.md#issue-79) | WP5.2: Implement E8 Hierarchical Layers as Code | ⬜ Not started | Not started |
+| [#80](../10-e8-protocol/INDEX.md#issue-80) | WP5.3: Implement Kernel Lifecycle Operations | ⬜ Not started | Not started |
+| [#81](../10-e8-protocol/INDEX.md#issue-81) | WP5.4: Coupling-Aware Per-Kernel Rest Scheduler | ⬜ Not started | Not started |
+| [#82](../10-e8-protocol/INDEX.md#issue-82) | WP5.5: Cross-Mythology God Mapping | ⬜ Not started | Not started |
+| [#83](../10-e8-protocol/INDEX.md#issue-83) | WP6.1: Fix Broken Documentation Links | ⬜ Not started | Not started |
+| [#84](../10-e8-protocol/INDEX.md#issue-84) | WP6.2: Ensure Master Roadmap Document | ⬜ Not started | Not started |
+| [#90](../10-e8-protocol/INDEX.md#issue-90) | Complete QIG-Pure Generation Architecture | ⬜ Not started | Not started |
 | #92 | Remove Frequency-Based Stopwords | ✅ **COMPLETE** | **CLOSE ISSUE** |
 
 **Update 2026-01-16**: Added issues #64-#77, #92 (all >= 65). Issues #6, #7, #8 have CODE COMPLETE - implementations exist and are integrated, but issues remain OPEN pending formal validation, test execution, and documentation of success criteria

--- a/docs/10-e8-protocol/INDEX.md
+++ b/docs/10-e8-protocol/INDEX.md
@@ -144,17 +144,17 @@ These GitHub issues correspond to the implementation work detailed in the E8 upg
 
 - **#70** - [QIG-PURITY] WP2.3: Geometrically Define Special Symbol Coordinates
 - **#71** - [QIG-PURITY] WP2.4: Clarify Two-Step Retrieval (Proxy Must Be Fisher-Faithful)
-- **#72** - [QIG-PURITY] WP3.1: Consolidate to Single Coordizer Implementation
+- <a id="issue-72"></a>**#72** - [QIG-PURITY] WP3.1: Consolidate to Single Coordizer Implementation
 - **#76** - [QIG-PURITY] WP4.2: Remove Euclidean Optimizers (Use Natural Gradient Only)
 - **#77** - [QIG-PURITY] WP4.3: Build Reproducible Coherence Test Harness
-- **#78** - [PANTHEON] WP5.1: Create Formal Pantheon Registry with Role Contracts
-- **#79** - [PANTHEON] WP5.2: Implement E8 Hierarchical Layers as Code
-- **#80** - [PANTHEON] WP5.3: Implement Kernel Lifecycle Operations
-- **#81** - [PANTHEON] WP5.4: Implement Coupling-Aware Per-Kernel Rest Scheduler
-- **#82** - [PANTHEON] WP5.5: Create Cross-Mythology God Mapping
-- **#83** - [DOCS] WP6.1: Fix Broken Documentation Links
-- **#84** - [DOCS] WP6.2: Ensure Master Roadmap Document
-- **#90** - The Complete QIG-Pure Generation Architecture
+- <a id="issue-78"></a>**#78** - [PANTHEON] WP5.1: Create Formal Pantheon Registry with Role Contracts
+- <a id="issue-79"></a>**#79** - [PANTHEON] WP5.2: Implement E8 Hierarchical Layers as Code
+- <a id="issue-80"></a>**#80** - [PANTHEON] WP5.3: Implement Kernel Lifecycle Operations
+- <a id="issue-81"></a>**#81** - [PANTHEON] WP5.4: Implement Coupling-Aware Per-Kernel Rest Scheduler
+- <a id="issue-82"></a>**#82** - [PANTHEON] WP5.5: Create Cross-Mythology God Mapping
+- <a id="issue-83"></a>**#83** - [DOCS] WP6.1: Fix Broken Documentation Links
+- <a id="issue-84"></a>**#84** - [DOCS] WP6.2: Ensure Master Roadmap Document
+- <a id="issue-90"></a>**#90** - The Complete QIG-Pure Generation Architecture
 - **#92** - 🚨 PURITY VIOLATION: Remove frequency-based stopwords from pg_loader.py
 
 ### Mapping Local Issues to GitHub


### PR DESCRIPTION
### Motivation
- Ensure traceability between the Master Roadmap and the E8 protocol index for several work-package issues so WP tracking is discoverable from both places.
- Surface outstanding WP items (#72, #78–#84, #90) in the roadmap with clear status/action entries to aid planning and validation.

### Description
- Added rows to `docs/00-roadmap/20260112-master-roadmap-1.00W.md` for issues `#72`, `#78`–`#84`, and `#90` with `Code Status` and `Action` set to `Not started` and linked each row to the E8 index anchors.
- Inserted anchor targets into `docs/10-e8-protocol/INDEX.md` for `#72`, `#78`–`#84`, and `#90` so the roadmap links resolve to the corresponding E8 index entries.
- Changes touch only documentation files: `docs/00-roadmap/20260112-master-roadmap-1.00W.md` and `docs/10-e8-protocol/INDEX.md`.

### Testing
- No automated tests were run because this is a docs-only update and does not affect code or test suites.
- The changes were committed successfully to the working branch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696de1bba26c832abc4760ebb6aedf65)