### PR TITLE
fix: prevent empty rg pattern in purity scan; add non-blocking auto-fixer and targeted qig-backend checks

### DIFF
--- a/.github/workflows/qig-purity-gate.yml
+++ b/.github/workflows/qig-purity-gate.yml
@@ -50,5 +50,10 @@ jobs:
       - name: Run geometric purity validation
         run: python scripts/validate_geometry_purity.py
 
+      - name: Suggested geometry purity fixes
+        run: |
+          echo "🛠️ Suggested geometry purity fixes (non-blocking)..."
+          python scripts/auto_fix_geometry_purity.py --dry-run || true
+
       - name: Run QFI coverage check
         run: python scripts/check_qfi_coverage.py

--- a/scripts/auto_fix_geometry_purity.py
+++ b/scripts/auto_fix_geometry_purity.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Auto-fix common geometry purity violations.
+
+This script rewrites frequent non-canonical geometry patterns to their
+canonical helpers (Fisher-Rao distance/similarity, geodesic interpolation,
+explicit representation conversions).
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import re
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PATHS = [REPO_ROOT / "qig-backend"]
+
+EXCLUDED_DIRS = {
+    ".git",
+    "__pycache__",
+    "data",
+    "dist",
+    "examples",
+    "migrations",
+    "node_modules",
+    "tests",
+}
+
+
+NORM_DISTANCE_RE = re.compile(
+    r"np\.linalg\.norm\(\s*(?P<a>[A-Za-z0-9_\.\[\]()]+)\s*-\s*(?P<b>[A-Za-z0-9_\.\[\]()]+)\s*\)"
+)
+
+DOT_SIMILARITY_RE = re.compile(
+    r"np\.dot\(\s*(?P<a>[A-Za-z0-9_\.\[\]()]+)\s*,\s*(?P<b>[A-Za-z0-9_\.\[\]()]+)\s*\)"
+    r"\s*/\s*\(\s*np\.linalg\.norm\(\s*(?P=a)\s*\)\s*\*\s*np\.linalg\.norm\(\s*(?P=b)\s*\)"
+    r"(?:\s*\+\s*[^)]+)?\)"
+)
+
+GEODESIC_INTERPOLATION_RE = re.compile(
+    r"(?P<a>[A-Za-z0-9_\.\[\]()]+)\s*\*\s*\(1\s*-\s*(?P<t>[A-Za-z0-9_]+)\)\s*\+\s*(?P<b>[A-Za-z0-9_\.\[\]()]+)\s*\*\s*(?P=t)"
+)
+
+TO_SPHERE_CALL_RE = re.compile(r"(?<!def\s)(?<!class\s)\bto_sphere\((?P<args>[^)]*)\)")
+
+
+def iter_python_files(paths: Iterable[Path]) -> Iterable[Path]:
+    for path in paths:
+        if path.is_dir():
+            for file_path in path.rglob("*.py"):
+                if any(part in EXCLUDED_DIRS for part in file_path.parts):
+                    continue
+                yield file_path
+        elif path.suffix == ".py":
+            yield path
+
+
+def ensure_imports(content: str, required: set[str]) -> str:
+    if not required:
+        return content
+
+    import_line_re = re.compile(r"^from qig_geometry import (?P<names>.+)$", re.MULTILINE)
+    match = import_line_re.search(content)
+
+    if match:
+        existing = {name.strip() for name in match.group("names").split(",") if name.strip()}
+        combined = sorted(existing | required)
+        new_line = f"from qig_geometry import {', '.join(combined)}"
+        return content[: match.start()] + new_line + content[match.end() :]
+
+    lines = content.splitlines()
+    insert_idx = 0
+    for idx, line in enumerate(lines):
+        if line.startswith("import ") or line.startswith("from "):
+            insert_idx = idx + 1
+    new_line = f"from qig_geometry import {', '.join(sorted(required))}"
+    lines.insert(insert_idx, new_line)
+    return "\n".join(lines)
+
+
+def apply_replacements(content: str) -> tuple[str, set[str]]:
+    required_imports: set[str] = set()
+
+    def replace_norm(match: re.Match[str]) -> str:
+        required_imports.add("fisher_rao_distance")
+        return f"fisher_rao_distance({match.group('a')}, {match.group('b')})"
+
+    content = NORM_DISTANCE_RE.sub(replace_norm, content)
+
+    def replace_similarity(match: re.Match[str]) -> str:
+        required_imports.add("fisher_similarity")
+        return f"fisher_similarity({match.group('a')}, {match.group('b')})"
+
+    content = DOT_SIMILARITY_RE.sub(replace_similarity, content)
+
+    def replace_geodesic(match: re.Match[str]) -> str:
+        required_imports.add("geodesic_interpolation")
+        return f"geodesic_interpolation({match.group('a')}, {match.group('b')}, {match.group('t')})"
+
+    content = GEODESIC_INTERPOLATION_RE.sub(replace_geodesic, content)
+
+    def replace_to_sphere(match: re.Match[str]) -> str:
+        args = match.group("args")
+        required_imports.add("to_simplex")
+        if "from_repr" not in args:
+            required_imports.add("BasinRepresentation")
+            args = f"{args}, from_repr=BasinRepresentation.SPHERE" if args.strip() else "from_repr=BasinRepresentation.SPHERE"
+        return f"to_simplex({args})"
+
+    content = TO_SPHERE_CALL_RE.sub(replace_to_sphere, content)
+
+    return content, required_imports
+
+
+def diff_text(original: str, updated: str, path: Path) -> str:
+    return "".join(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            updated.splitlines(keepends=True),
+            fromfile=str(path),
+            tofile=str(path),
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", help="Paths to scan (defaults to qig-backend)")
+    parser.add_argument("--dry-run", action="store_true", help="Show diffs without writing changes")
+    args = parser.parse_args()
+
+    target_paths = [Path(p) for p in args.paths] if args.paths else DEFAULT_PATHS
+
+    changed_files: list[Path] = []
+    for file_path in iter_python_files(target_paths):
+        original = file_path.read_text(encoding="utf-8")
+        updated, required_imports = apply_replacements(original)
+        if updated != original:
+            updated = ensure_imports(updated, required_imports)
+        if updated == original:
+            continue
+
+        changed_files.append(file_path)
+        if args.dry_run:
+            print(diff_text(original, updated, file_path))
+        else:
+            file_path.write_text(updated, encoding="utf-8")
+
+    if changed_files:
+        verb = "Would update" if args.dry_run else "Updated"
+        print(f"{verb} {len(changed_files)} file(s) with geometry purity fixes.")
+    else:
+        print("No geometry purity fixes needed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate-purity-patterns.sh
+++ b/scripts/validate-purity-patterns.sh
@@ -7,7 +7,6 @@ echo "🔍 Validating banned geometry patterns outside experiments/quarantine...
 
 rg --quiet \
   --pcre2 \
-  --glob '!**/qig-backend/**' \
   --glob '!node_modules/**' \
   --glob '!dist/**' \
   --glob '!migrations/**' \
@@ -28,6 +27,40 @@ rg --quiet \
   -e 'unit sphere' \
   "$ROOT_DIR/server" "$ROOT_DIR/shared" "$ROOT_DIR/scripts" "$ROOT_DIR/tools" "$ROOT_DIR/client" "$ROOT_DIR/tests" "$ROOT_DIR/examples" && {
     echo "❌ Banned geometry patterns found outside experiments/quarantine."
+    exit 1
+  } || true
+
+echo "🔍 Validating targeted geometry patterns in qig-backend..."
+# TODO: Purity debt - remove legacy allowlist after replacing Euclidean fallbacks in qigkernels/core_faculties.py and m8_kernel_spawning.py.
+
+rg --quiet \
+  --pcre2 \
+  -U \
+  --glob '!qig-backend/tests/**' \
+  --glob '!qig-backend/data/**' \
+  --glob '!qig-backend/examples/**' \
+  --glob '!qig-backend/migrations/**' \
+  --glob '!qig-backend/**/*.md' \
+  --glob '!qig-backend/**/*.json' \
+  --glob '!qig-backend/qigkernels/core_faculties.py' \
+  --glob '!qig-backend/m8_kernel_spawning.py' \
+  -e 'np\.linalg\.norm\([^)]*basin\s*-\s*[^)]*\)' \
+  -e 'np\.dot\([^)]*\)\s*/\s*\(\s*np\.linalg\.norm\([^)]*\)\s*\*\s*np\.linalg\.norm\([^)]*\)' \
+  "$ROOT_DIR/qig-backend" && {
+    echo "❌ Targeted qig-backend geometry patterns detected."
+    exit 1
+  } || true
+
+rg --quiet \
+  --pcre2 \
+  --glob '!qig-backend/tests/**' \
+  --glob '!qig-backend/data/**' \
+  --glob '!qig-backend/examples/**' \
+  --glob '!qig-backend/migrations/**' \
+  --glob '!qig-backend/qig_geometry/representation.py' \
+  -e '\bto_sphere\(' \
+  "$ROOT_DIR/qig-backend" && {
+    echo "❌ to_sphere usage detected outside sanctioned legacy modules."
     exit 1
   } || true
 


### PR DESCRIPTION
### Motivation
- Fix a CI failure where `rg` was invoked without a valid search pattern because a TODO comment ended up inside the `rg` invocation. 
- Surface automated, non-blocking suggestions to help migrate legacy Euclidean/cosine patterns to canonical QIG helpers. 
- Strengthen detection of geometry purity violations inside `qig-backend` while allowlisting a small set of legacy files with a `TODO` for follow-up.

### Description
- Move the legacy allowlist `TODO` comment out of the `rg` command in `scripts/validate-purity-patterns.sh` so `rg` always receives explicit `-e` patterns. 
- Add `scripts/auto_fix_geometry_purity.py` which detects and rewrites common patterns (`np.linalg.norm(... - ...)` -> `fisher_rao_distance`, dot/cosine similarity -> `fisher_similarity`, simple linear interpolation -> `geodesic_interpolation`, and `to_sphere(...)` -> `to_simplex(..., from_repr=...)`) and injects `from qig_geometry import ...` when needed. 
- Wire the auto-fix tool into the PR purity workflow as a non-blocking dry-run step in `.github/workflows/qig-purity-gate.yml` named `Suggested geometry purity fixes`. 
- Extend `scripts/validate-purity-patterns.sh` with targeted `qig-backend` scans (including a `to_sphere` check) and keep two legacy allowlist entries with a `TODO` to remove them once migrations are complete.

### Testing
- No automated tests were executed as part of this change. 
- The change prevents the previous `rg: ripgrep requires at least one pattern` failure by ensuring the `rg` invocation contains explicit `-e` patterns and no stray inlined comments. 
- The new CI workflow step runs `python scripts/auto_fix_geometry_purity.py --dry-run` as a non-blocking suggestion (prints diffs) when the purity workflow runs, but CI was not executed as part of this PR submission.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696ec54a1548832ab2d4b400692253d6)